### PR TITLE
Fixed up LTI App - got endpoints verified as working (hopefully - they work on localhost)

### DIFF
--- a/backend/lti_service/app.py
+++ b/backend/lti_service/app.py
@@ -2,32 +2,38 @@ import os, json
 from flask import Flask, request, jsonify
 from dotenv import load_dotenv
 from pylti1p3.contrib.flask import (
-    FlaskOIDCLogin, FlaskMessageLaunch, FlaskDbToolConf, FlaskRequest
+    FlaskOIDCLogin, FlaskMessageLaunch, FlaskRequest, FlaskCacheDataStorage
 )
+from pylti1p3.tool_config import ToolConfDict
 
-TOOL_JWKS = {"keys": []}  # replace with  real JWKS later
 load_dotenv("config/.env")
 
-# simplified tool config storage class -> hardcoding Canvas issuers and endpoints, reading it from env variables (config.ini) 
-# in prod we should have a DB with per platform (LMS) registrations
-class ToolConfStorage:
-    def find_registration(self, iss): #returns Canvas metadata so PyLTIp3 can validate launch 
-        return {
-            "issuer": "https://canvas.instructure.com",
-            "client_id": os.environ["CANVAS_CLIENT_ID"],
-            "auth_login_url": os.environ["CANVAS_OIDC_AUTH_URL"],
-            "auth_token_url": os.environ["CANVAS_TOKEN_URL"],
-            "key_set_url": os.environ["CANVAS_JWKS_URL"],
-            "audience": os.environ["CANVAS_CLIENT_ID"]
-        }
-    def get_jwt_verify_keys(self, iss): #left empty for now becauase PyLTIp3 will fetch Canvas JWT keys automatically from key_set_url. (will  have to implement this for other LMS)
-        return None
+# ---- Tool Configuration ----- #
+ISSUER = "https://canvas.instructure.com"
+
+tool_conf = ToolConfDict({
+    ISSUER: [{
+        "default": True,
+        "client_id": os.environ["CANVAS_CLIENT_ID"],
+        "auth_login_url": os.environ["CANVAS_OIDC_AUTH_URL"],
+        "auth_token_url": os.environ["CANVAS_TOKEN_URL"],
+        "auth_audience": os.environ.get("CANVAS_TOKEN_AUDIENCE"),  # often same as token URL; ok if missing
+        "key_set_url": os.environ["CANVAS_JWKS_URL"],
+        # For deep linking / tool-signed JWTs, set one of the following:
+        # "private_key_file": "config/private.key",
+        # "public_key_file": "config/public.key",
+        # or inline:
+        # "private_key": os.environ.get("TOOL_PRIVATE_KEY_PEM"),
+        # "public_key": os.environ.get("TOOL_PUBLIC_KEY_PEM"),
+        "deployment_ids": [os.environ.get("CANVAS_DEPLOYMENT_ID", "")]  # optional but recommended
+    }]
+})
 
 
-#wrap storage in flask adapter, start flask app, 
-tool_conf = FlaskDbToolConf(ToolConfStorage()) 
+# ---- Flask App ---- #
 app = Flask(__name__)
 app.secret_key = os.environ.get("FLASK_SECRET", "change-me")
+TOOL_JWKS = {"keys": []}  # replace with  actual tool JWKS later when we start signing responses
 
 
 @app.route("/jwks.json")

--- a/backend/lti_service/app.py
+++ b/backend/lti_service/app.py
@@ -43,17 +43,11 @@ def jwks():
 
 @app.route("/oidc-login", methods=["POST"])
 def oidc_login():
-    # Canvas posts iss, login_hint, target_link_uri (and maybe lti_message_hint)
     login = FlaskOIDCLogin(FlaskRequest(), tool_conf)
-    iss = request.form["iss"]
-    login_hint = request.form.get("login_hint", "")
+    # The library reads iss/login_hint/lti_message_hint from the request object
     target_link_uri = request.form["target_link_uri"]
-    lti_message_hint = request.form.get("lti_message_hint")
-    return login.redirect(
-        iss, login_hint,
-        target_link_uri=target_link_uri,
-        lti_message_hint=lti_message_hint
-    )
+    return login.redirect(target_link_uri)    # only pass the target link URI
+
 
 @app.route("/launch", methods=["POST"])
 def launch():

--- a/backend/lti_service/app.py
+++ b/backend/lti_service/app.py
@@ -1,0 +1,68 @@
+import os, json
+from flask import Flask, request, jsonify
+from dotenv import load_dotenv
+from pylti1p3.contrib.flask import (
+    FlaskOIDCLogin, FlaskMessageLaunch, FlaskDbToolConf, FlaskRequest
+)
+
+TOOL_JWKS = {"keys": []}  # replace with  real JWKS later
+load_dotenv("config/.env")
+
+# simplified toool config storage class -> hardcoding Canvas issuers and endpoints, reading it from env variables (config.ini) 
+# in prod we should have a DB with per platform (LMS) registrations
+class ToolConfStorage:
+    def find_registration(self, iss): #returns Canvas metadata so PyLTIp3 can validate launch 
+        return {
+            "issuer": "https://canvas.instructure.com",
+            "client_id": os.environ["CANVAS_CLIENT_ID"],
+            "auth_login_url": os.environ["CANVAS_OIDC_AUTH_URL"],
+            "auth_token_url": os.environ["CANVAS_TOKEN_URL"],
+            "key_set_url": os.environ["CANVAS_JWKS_URL"],
+            "audience": os.environ["CANVAS_CLIENT_ID"]
+        }
+    def get_jwt_verify_keys(self, iss): #left empty for now becauase PyLTIp3 will fetch Canvas JWT keys automatically from key_set_url. (will  have to implement this for other LMS)
+        return None
+
+
+#wrap storage in flask adapter, start flask app, 
+tool_conf = FlaskDbToolConf(ToolConfStorage()) 
+app = Flask(__name__)
+app.secret_key = os.environ.get("FLASK_SECRET", "change-me")
+
+
+@app.route("/jwks.json")
+def jwks():
+    # Serve public keys so Canvas can validate any JWTs (e.g., for Deep Linking responses).
+    return jsonify(TOOL_JWKS)
+
+@app.route("/oidc-login", methods=["POST"])
+def oidc_login():
+    # Canvas posts iss, login_hint, target_link_uri (and maybe lti_message_hint)
+    login = FlaskOIDCLogin(FlaskRequest())
+    iss = request.form["iss"]
+    login_hint = request.form.get("login_hint", "")
+    target_link_uri = request.form["target_link_uri"]
+    lti_message_hint = request.form.get("lti_message_hint")
+    return login.redirect(
+        tool_conf, iss, login_hint,
+        target_link_uri=target_link_uri,
+        lti_message_hint=lti_message_hint
+    )
+
+@app.route("/launch", methods=["POST"])
+def launch():
+    # Validate id_token (signature, iss/aud/exp, state/nonce)
+    ml = FlaskMessageLaunch(FlaskRequest(), tool_conf).validate()
+    launch_data = ml.get_launch_data()
+    # TODO: persist ml/launch_data for later AGS calls: ml.get_ags(), ml.get_nrps()
+    # For now, just confirm it worked.
+    return jsonify({
+        "status": "ok",
+        "platform": launch_data.get("iss"),
+        "user_sub": launch_data.get("sub"),
+        "roles": launch_data.get("https://purl.imsglobal.org/spec/lti/claim/roles", []),
+        "context": launch_data.get("https://purl.imsglobal.org/spec/lti/claim/context", {})
+    })
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=int(os.environ.get("PORT", 8080)))

--- a/backend/lti_service/app.py
+++ b/backend/lti_service/app.py
@@ -44,13 +44,13 @@ def jwks():
 @app.route("/oidc-login", methods=["POST"])
 def oidc_login():
     # Canvas posts iss, login_hint, target_link_uri (and maybe lti_message_hint)
-    login = FlaskOIDCLogin(FlaskRequest())
+    login = FlaskOIDCLogin(FlaskRequest(), tool_conf)
     iss = request.form["iss"]
     login_hint = request.form.get("login_hint", "")
     target_link_uri = request.form["target_link_uri"]
     lti_message_hint = request.form.get("lti_message_hint")
     return login.redirect(
-        tool_conf, iss, login_hint,
+        iss, login_hint,
         target_link_uri=target_link_uri,
         lti_message_hint=lti_message_hint
     )

--- a/backend/lti_service/app.py
+++ b/backend/lti_service/app.py
@@ -8,7 +8,7 @@ from pylti1p3.contrib.flask import (
 TOOL_JWKS = {"keys": []}  # replace with  real JWKS later
 load_dotenv("config/.env")
 
-# simplified toool config storage class -> hardcoding Canvas issuers and endpoints, reading it from env variables (config.ini) 
+# simplified tool config storage class -> hardcoding Canvas issuers and endpoints, reading it from env variables (config.ini) 
 # in prod we should have a DB with per platform (LMS) registrations
 class ToolConfStorage:
     def find_registration(self, iss): #returns Canvas metadata so PyLTIp3 can validate launch 

--- a/backend/lti_service/config/.env
+++ b/backend/lti_service/config/.env
@@ -1,0 +1,8 @@
+#manually setting these configs for now, in the future (prod) lets add these to our VM on docker or however it works idk
+
+CANVAS_CLIENT_ID=123456
+CANVAS_OIDC_AUTH_URL=https://sso.canvaslms.com/api/lti/authorize_redirect
+CANVAS_TOKEN_URL=https://sso.canvaslms.com/login/oauth2/token
+CANVAS_JWKS_URL=https://sso.canvaslms.com/api/lti/security/jwks
+FLASK_SECRET=some-long-random-string
+


### PR DESCRIPTION
### TL;DR
Almost ready to launch the LTI app to Canvas 🎉  
The app doesn’t do anything functional yet , this code is just to get Gradewise linked to Canvas. Still need to configure JWKS and a few other small details.

---

### Code Changes

* **Tool configuration fix**  
  - Originally tried to import `FlaskDbToolConf` (no longer available in `pylti1p3.contrib.flask`), which broke the app at startup.  
  - Replaced it with `ToolConfDict` from `pylti1p3.tool_config`, keyed by the Canvas `issuer`.  
  - This supplies our `client_id`, OIDC login URL, token URL, and JWKS URL to the library so that PyLTI1p3 can validate launches correctly.

* **OIDC login endpoint fixed**  
  - The `/oidc-login` handler was using an old/deprecated `login.redirect()` signature, which threw 500 errors.  
  - Updated to the current PyLTI1p3 API: only pass `target_link_uri` (the launch URL), while the library reads the other values (`iss`, `login_hint`, `lti_message_hint`) from the request.  
  - Now a POST to `/oidc-login` returns the expected **302 redirect to Canvas SSO**, which is step one of the LTI handshake.

---

### Ok cool, but what does this mean?

- Our Flask app now has the **three critical endpoints** working and reachable over HTTPS through Cloudflare Tunnel:
  - `/jwks.json` → exposes our public keys to Canvas  
  - `/oidc-login` → Canvas calls this when a user clicks the Gradewise app  
  - `/launch` → Canvas will POST the `id_token` JWT here after login  

- proved the flow works:
  - Curling `/oidc-login` returns a proper 302 redirect to Canvas’ SSO endpoint  
  - Canvas would next POST back to `/launch` with a signed token, which our code is ready to validate  

- **In simpler terms:** Gradewise can now “talk” to Canvas. Once UFIT provides a Developer Key (client ID + scopes) and I finalize configs like JWKS, we’ll be able to install Gradewise in the test course and see real launches working inside Canvas.