### PR TITLE
Fix Windows build, add initial OpenAPI endpoint, and inject Temporal client

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -12,23 +12,23 @@ all: server worker
 
 internal/api/gen.go: api/api.yaml api/oapi-codegen.yaml
 	@echo "Generating API code from OpenAPI spec..."
-	time go generate
+	go generate
 
 generate: internal/api/gen.go
 
 server: generate
 	@echo "Building server..."
-	time go build -o $(BIN_DIR)/server $(APP_SERVER)/main.go
+	go build -o $(BIN_DIR)/server $(APP_SERVER)/main.go
 	@ls -lh $(BIN_DIR)/server
 
 worker: generate
 	@echo "Building worker..."
-	time go build -o $(BIN_DIR)/worker $(APP_WORKER)/main.go
+	go build -o $(BIN_DIR)/worker $(APP_WORKER)/main.go
 	@ls -lh $(BIN_DIR)/worker
 
 test:
 	@echo "Testing..."
-	time go test ./...
+	go test ./...
 
 clean:
 	rm -f $(BIN_DIR)/*

--- a/backend/api/api.yaml
+++ b/backend/api/api.yaml
@@ -27,3 +27,76 @@ paths:
                   message:
                     type: string
                     example: Hello, Alice! Goodbye!
+  /faculty/register:
+    post:
+      tags: [ Faculty ]
+      summary: Register a new faculty account
+      operationId: RegisterFaculty
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FacultyRegistrationRequest'
+      responses:
+        "201":
+          description: Faculty created (verification required)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FacultyRegistrationResponse'
+        "409":
+          description: Email already registered
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+
+components:
+  responses:
+    Unauthorized:
+      description: Unauthorized
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+
+    ErrorResponse:
+      description: Error
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+
+  schemas:
+    FacultyRegistrationRequest:
+      type: object
+      required: [ email, password, fullName ]
+      properties:
+        email: { type: string, format: email }
+        password: { type: string, minLength: 8 }
+        fullName: { type: string }
+        institution: { type: string }
+
+    FacultyRegistrationResponse:
+      type: object
+      required: [ facultyId, email, status ]
+      properties:
+        facultyId: { type: string, format: uuid }
+        email: { type: string, format: email }
+        status:
+          type: string
+          enum: [ PENDING_VERIFICATION, VERIFIED ]
+
+    Error:
+      type: object
+      required: [ code, message ]
+      properties:
+        code: { type: string, example: BAD_REQUEST }
+        message: { type: string, example: Invalid request }
+        details:
+          type: object
+          additionalProperties: true
+

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -3,11 +3,13 @@ package main
 import (
 	"gradewise/backend/internal/api"
 	"gradewise/backend/internal/database"
+	"gradewise/backend/internal/temporal"
 	"log"
 	"net/http"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"go.temporal.io/sdk/client"
 )
 
 func main() {
@@ -19,7 +21,20 @@ func main() {
 		log.Println("Continuing without database connection...")
 	}
 
-	server := api.NewServer()
+	var temporalClient client.Client
+	temporalClient, err = client.Dial(client.Options{
+		HostPort: temporal.GetTemporalAddress(),
+	})
+	if err != nil {
+		log.Printf("Failed to create Temporal client: %v", err)
+		log.Println("Continuing without Temporal (handlers should guard against nil)...")
+	} else {
+		defer temporalClient.Close()
+	}
+
+	// Build your server with injected deps
+	server := api.NewServer(temporalClient)
+
 	r := gin.Default()
 
 	// Health and monitoring endpoints
@@ -32,7 +47,7 @@ func main() {
 			"status": "ok",
 			"time":   gin.H{"timestamp": time.Now().Format(time.RFC3339)},
 		}
-		
+
 		// Add database health check
 		if db != nil {
 			if err := db.HealthCheck(); err != nil {
@@ -50,7 +65,7 @@ func main() {
 				"status": "not_connected",
 			}
 		}
-		
+
 		c.JSON(http.StatusOK, response)
 	})
 
@@ -67,7 +82,7 @@ func main() {
 		status, checkedAt, err := db.GetHealthCheckStatus()
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": "Failed to get health check status",
+				"error":   "Failed to get health check status",
 				"details": err.Error(),
 			})
 			return
@@ -76,15 +91,15 @@ func main() {
 		// Update health check
 		if err := db.UpdateHealthCheck("api_test"); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": "Failed to update health check",
+				"error":   "Failed to update health check",
 				"details": err.Error(),
 			})
 			return
 		}
 
 		c.JSON(http.StatusOK, gin.H{
-			"message": "Database test successful",
-			"last_status": status,
+			"message":      "Database test successful",
+			"last_status":  status,
 			"last_checked": checkedAt.Format(time.RFC3339),
 			"current_time": time.Now().Format(time.RFC3339),
 		})
@@ -93,9 +108,9 @@ func main() {
 	// Register the API handlers
 	api.RegisterHandlers(r, server)
 
-	s :=&http.Server{
+	s := &http.Server{
 		Handler: r,
-		Addr: "0.0.0.0:8080",
+		Addr:    "0.0.0.0:8080",
 	}
 
 	log.Fatalln(s.ListenAndServe())

--- a/backend/internal/api/impl.go
+++ b/backend/internal/api/impl.go
@@ -1,78 +1,65 @@
 package api
 
 import (
-	"context"
 	"gradewise/backend/internal/temporal"
 	"gradewise/backend/internal/temporal/workflow"
-	"log"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"go.temporal.io/sdk/client"
 )
 
 // Ensure that we've conformed to the `ServerInterface` with a compile-time check
 var _ ServerInterface = (*Server)(nil)
 
-type Server struct{}
-
-func NewServer() Server {
-	return Server{}
+type Server struct {
+	Temporal client.Client
 }
 
-func (Server) GreetUser(c *gin.Context, params GreetUserParams) {
-	// Create Temporal client
-	t, err := client.Dial(client.Options{
-		HostPort: temporal.GetTemporalAddress(),
-	})
-	if err != nil {
-		log.Println("Unable to create client", err)
-		c.Status(http.StatusInternalServerError)
+func NewServer(t client.Client) *Server {
+	return &Server{Temporal: t}
+}
+
+func (s *Server) RegisterFaculty(c *gin.Context) {
+	var req FacultyRegistrationRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, Error{Code: "BAD_REQUEST", Message: "invalid JSON body"})
 		return
 	}
-	defer t.Close()
 
-	we, err := t.ExecuteWorkflow(
-		context.Background(),
-		client.StartWorkflowOptions{
-			// ID: "",
-			TaskQueue: temporal.TaskQueueName,
-		},
+	// TODO: hash password, insert into Postgres, create verification code, send email... basically do everyting useful lol
+	c.JSON(http.StatusCreated, FacultyRegistrationResponse{
+		FacultyId: uuid.MustParse(uuid.NewString()), // matches openapi_types.UUID
+		Email:     req.Email,
+		Status:    PENDINGVERIFICATION,
+	})
+}
+
+func (s *Server) GreetUser(c *gin.Context, params GreetUserParams) {
+	if s.Temporal == nil {
+		c.String(http.StatusServiceUnavailable, "Temporal unavailable")
+		return
+	}
+
+	ctx := c.Request.Context()
+
+	we, err := s.Temporal.ExecuteWorkflow(
+		ctx,
+		client.StartWorkflowOptions{TaskQueue: temporal.TaskQueueName},
 		workflow.InteractWithMe,
 		params.Name,
 	)
 	if err != nil {
-		log.Println("Unable to execute workflow", err)
 		c.Status(http.StatusInternalServerError)
 		return
 	}
 
-	var workflowResult string
-	// err = we.Get(context.Background(), &workflowResult)
-	desc, err := t.DescribeWorkflowExecution(context.Background(), we.GetID(), we.GetRunID())
-	if err != nil {
-		log.Println("Unable to describe workflow execution")
+	var result string
+	if err := s.Temporal.GetWorkflow(ctx, we.GetID(), we.GetRunID()).Get(ctx, &result); err != nil {
 		c.Status(http.StatusInternalServerError)
 		return
 	}
 
-	log.Printf("Status = %d", desc.WorkflowExecutionInfo.Status)
-
-	err = t.GetWorkflow(context.Background(), we.GetID(), we.GetRunID()).Get(context.Background(), &workflowResult)
-	if err != nil {
-		log.Println("Unable to get workflow result", err)
-		c.Status(http.StatusInternalServerError)
-		return
-	}
-
-	desc, err = t.DescribeWorkflowExecution(context.Background(), we.GetID(), we.GetRunID())
-	if err != nil {
-		log.Println("Unable to describe workflow execution")
-		c.Status(http.StatusInternalServerError)
-		return
-	}
-
-	log.Printf("Status = %d", desc.WorkflowExecutionInfo.Status)
-
-	c.JSON(http.StatusOK, workflowResult)
+	c.JSON(http.StatusOK, result)
 }


### PR DESCRIPTION
**Summary**
This PR makes the build work on Windows, adds a first OpenAPI-backed endpoint for faculty registration, and refactors how we use the Temporal client to avoid per-request dials.

**What changed**

- Makefile
    - Removed time wrapper from go generate/build/test (Windows shell couldn’t execute time, causing CreateProcess errors).
    - Build/test now call go directly.

- OpenAPI spec (api/api.yaml)
    - Added POST `/faculty/register` with request/response schemas (FacultyRegistrationRequest, FacultyRegistrationResponse, Error).

- Server wiring (cmd/server/main.go)
     - Created a single Temporal client at startup and passed it into the API server (api.NewServer(temporalClient)).
    - Minor logging/formatting tweaks.

- Handlers (internal/api/impl.go)
    - Server now holds an injected Temporal client.Client.
    - GreetUser uses the injected client + request context (no per-request client.Dial).
    - New handler RegisterFaculty: binds JSON, returns a stubbed 201 with a generated UUID and PENDING_VERIFICATION status (Next step is working on implementing interaction with database just wanted to start here so PR is smaller and easier to look over)