### PR TITLE
Schema for tables

### DIFF
--- a/backend/migrations/001_create_main_tables.up.sql
+++ b/backend/migrations/001_create_main_tables.up.sql
@@ -1,0 +1,84 @@
+-- UUID generator
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- ========== FACULTY (accounts) ==========
+CREATE TABLE IF NOT EXISTS faculty (
+    id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    email         text NOT NULL UNIQUE,
+    pass_hash     text NOT NULL,
+    full_name     text NOT NULL,
+    institution   text,
+    status        text NOT NULL DEFAULT 'PENDING_VERIFICATION'
+    CHECK (status IN ('PENDING_VERIFICATION','VERIFIED')),
+    verified_at   timestamptz,
+    created_at    timestamptz NOT NULL DEFAULT now(),
+    updated_at    timestamptz NOT NULL DEFAULT now()
+    );
+
+-- verification codes for sign-up
+CREATE TABLE IF NOT EXISTS faculty_verifications (
+    email       text PRIMARY KEY REFERENCES faculty(email) ON DELETE CASCADE,
+    code        text NOT NULL,
+    expires_at  timestamptz NOT NULL,
+    created_at  timestamptz NOT NULL DEFAULT now()
+    );
+
+-- ========== COURSES ==========
+CREATE TABLE IF NOT EXISTS courses (
+                                       id                 uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    code               text NOT NULL,          -- e.g. "CS101"
+    term               text NOT NULL,          -- e.g. "Fall 2025"
+    title              text NOT NULL,
+    section            text,                   -- nullable; some schools use it
+    start_date         date,
+    end_date           date,
+    creator_faculty_id uuid NOT NULL REFERENCES faculty(id) ON DELETE RESTRICT,
+    created_at         timestamptz NOT NULL DEFAULT now(),
+    updated_at         timestamptz NOT NULL DEFAULT now()
+    );
+
+-- ========== GRADERS (TAs/graders per course) ==========
+DO $$ BEGIN
+CREATE TYPE grader_role AS ENUM ('GRADER','TA');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+CREATE TABLE IF NOT EXISTS course_graders (
+                                              course_id  uuid NOT NULL REFERENCES courses(id) ON DELETE CASCADE,
+    faculty_id uuid NOT NULL REFERENCES faculty(id) ON DELETE CASCADE,
+    role       grader_role NOT NULL DEFAULT 'GRADER',
+    added_at   timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (course_id, faculty_id)
+    );
+
+-- ========== STUDENTS + ENROLLMENTS (roster) ==========
+CREATE TABLE IF NOT EXISTS students (
+                                        id         uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    email      text NOT NULL UNIQUE,
+    full_name  text NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now()
+    );
+
+CREATE TABLE IF NOT EXISTS enrollments (
+    course_id  uuid NOT NULL REFERENCES courses(id) ON DELETE CASCADE,
+    student_id uuid NOT NULL REFERENCES students(id) ON DELETE CASCADE,
+    added_at   timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (course_id, student_id)
+    );
+
+-- ========== ROSTER UPLOAD JOBS (for CSV uploads) ==========
+CREATE TABLE IF NOT EXISTS roster_import_jobs (
+                                                  id         uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    course_id  uuid NOT NULL REFERENCES courses(id) ON DELETE CASCADE,
+    filename   text NOT NULL,
+    status     text NOT NULL DEFAULT 'QUEUED'
+    CHECK (status IN ('QUEUED','PROCESSING','DONE','FAILED')),
+    has_header boolean NOT NULL DEFAULT true,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    error      text
+    );
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS courses_creator_idx     ON courses(creator_faculty_id);
+CREATE INDEX IF NOT EXISTS graders_course_idx      ON course_graders(course_id, faculty_id);
+CREATE INDEX IF NOT EXISTS enrollments_course_idx  ON enrollments(course_id);


### PR DESCRIPTION
# New Tables

## faculty
- A record for accounts (email, password hash, status being verified or not, timestamps)

## faculty_verifications
- An active code per email that expires

## courses
- A course that's offered (code, term, title, section, creator, dates (optional))

## course_graders
- Many to many faculty with a `grader_role` enum (grader / TA)

## Indexes
- This is here just because they might be useful in the future. I don't mind if we want to delete now and have them as needed but I thought they might be useful.

## Considerations
- I was debating if we just wanted to add `uuid` generation in the Go code or wherever but then an issue arises when someone maybe wants to use this API in the future and they run into issues with their own generation. This seems like a single source of truth and keeps things simple.
- Did some foreign key considerations like not being able to delete a faculty that owns courses, cleaning up when a course is deleted, etc. Feel free to drop some comments if you're curious about anything


## Verification
- Long story short, had to exec into the pod and apply via `psql`. This was done as a migration as to not have to change the postgres init file. This will need to be done on the prod computer. Pretty simple commands something along the lines of
```
pod=$(kubectl get pods -l app=postgres -o jsonpath='{.items[0].metadata.name}')

kubectl exec -i "$pod" -- env PGPASSWORD=password   psql -U postgres -d gradewise_api < backend/migrations/001_create_main_tables.up.sql
``` 

