### PR TITLE
Move schema migrations into Postgres init script

### DIFF
--- a/k8s/backend/postgres-deployment.yaml
+++ b/k8s/backend/postgres-deployment.yaml
@@ -46,6 +46,8 @@ data:
     GRANT ALL PRIVILEGES ON SCHEMA public TO temporal_user;
     \c temporal_visibility;
     GRANT ALL PRIVILEGES ON SCHEMA public TO temporal_user;
+    
+    \c gradewise_api;
     -- UUID generator
     CREATE
     EXTENSION IF NOT EXISTS pgcrypto;


### PR DESCRIPTION
- Copied the existing migration SQL into the Postgres init script so the gradewise_api schema (faculty, courses, graders, students, enrollments, roster_import_jobs) and grants are created automatically when the database is first initialized.
- This means when the container starts with a fresh volume, all tables and permissions are created without needing to run manual migrations.